### PR TITLE
added is_in_vga for checking if hexcode is in vga palette

### DIFF
--- a/colorcodetools/hex/validate.py
+++ b/colorcodetools/hex/validate.py
@@ -9,3 +9,20 @@ def is_hex(hexcode: str) -> bool:
         if e >= "g":
             return False
     return True
+
+
+def is_in_vga(hexcode: str) -> bool:
+    if hexcode.startswith('#'):
+        hex_check: str = hexcode.replace('#', '')
+    else:
+        hex_check: str = hexcode
+    if len(hex_check) != 6 and len(hex_check) != 3:
+        return False
+    if hex_check.lower() in __config_is_vga():
+        return True
+    return False
+
+
+def __config_is_vga() -> list:
+    return ['000000', '800000', '008000', '808000', '000080', '800080', '008080', 'c0c0c0', '808080', 'ff0000',
+            '00ff00', 'ffff00', '0000ff', 'ff00ff', '00ffff', 'ffffff']

--- a/docs/modules/hex/validate.py/is_in_vga.md
+++ b/docs/modules/hex/validate.py/is_in_vga.md
@@ -1,0 +1,26 @@
+# is_in_vga()
+
+## How to use
+
+1. ```python
+   from colorcodetools.hex.validate import is_in_vga
+   is_in_vga('hexcode')
+   ```
+2. ```python
+   import colorcodetools
+   colorcodetools.hex.validate.is_in_vga('hexcode')
+   ```
+
+## Parameters
+
+1. Required parameters:
+
+   - hexcode:  
+      Enter hex code which should be checked.
+     - `type: string`
+     - `default: None`
+     - `example: #f0f0f0`
+
+## Return value
+
+- `type: boolean`


### PR DESCRIPTION
**Which issue is this pull request related to?**

[Add vga palette support ](https://github.com/TheKeineAhnung/colorcodetools/issues/11)

**What did you change?**

Added function to check if hexcode is in vga palette.